### PR TITLE
Add method to find next active time.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const config = {
   testMatch: ['**/*.test.ts'],
   transform: { '^.+\\.(ts|tsx)$': 'ts-jest' },
   timers: 'modern',
+  globalSetup: '<rootDir>/src/tests/global-setup.js',
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "type": "git",
     "url": "git@github.com:NimaiMalle/go-time.git"
   },
-  "jest": {
-    "globalSetup": "./src/tests/global-setup.js"
-  },
   "scripts": {
     "build": "eslint . --ext .ts && tsc",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimaimalle/go-time",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Define recurring blocks of time and test for containment",
   "prepublish": "eslint . --ext .ts && tsc",
   "main": "dist/index.js",
@@ -12,6 +12,9 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:NimaiMalle/go-time.git"
+  },
+  "jest": {
+    "globalSetup": "./src/tests/global-setup.js"
   },
   "scripts": {
     "build": "eslint . --ext .ts && tsc",

--- a/src/tests/global-setup.js
+++ b/src/tests/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC'
+}

--- a/src/tests/gotime.test.ts
+++ b/src/tests/gotime.test.ts
@@ -11,6 +11,12 @@ test.each`
 });
 */
 
+describe('Timezones', () => {
+  it('should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0)
+  })
+})
+
 test('Halloween week', () => {
   const definition = 'M=Oct; DoM>=24'
   const goTime = new GoTime(definition)
@@ -94,4 +100,39 @@ test('Any time, between two datetimes', () => {
   expect(goTime.test(new Date('2022-03-21'))).toBeTruthy()
   expect(goTime.test(new Date('2022-03-20 12:59:00'))).toBeFalsy()
   expect(goTime.test(new Date('2022-03-22 06:00:00'))).toBeFalsy()
+})
+
+test('Next available', () => {
+  let goTime: GoTime
+  let next: Date | null
+
+  goTime = new GoTime('M=Oct; DoM>=24')
+  next = goTime.next(new Date(2022, 9, 20), new Date(2022, 10, 1))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('DoM<7; DoW=Sat,Sun')
+  next = goTime.next(new Date(2022, 8, 28), new Date(2022, 9, 7))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('Time=00:00-01:00; Time=12:00-13:00')
+  next = goTime.next(new Date(2022, 2, 1, 18, 5), new Date(2022, 2, 7))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('DoY=46')
+  next = goTime.next(new Date(2022, 1, 14), new Date(2022, 1, 20))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('DoW=Tue-Sun')
+  next = goTime.next(new Date('2022-4-4'), new Date('2022-4-9'))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('Datetime>=2022-03-20 13:00:00')
+  next = goTime.next(new Date('2022-03-20 12:00:00'), new Date('2022-03-27'))
+  expect(goTime.test(next)).toBeTruthy()
+
+  goTime = new GoTime('Datetime=2022-03-20 13:00:00|2022-03-22 05:30:00')
+  next = goTime.next(new Date('2022-03-18'), new Date('2022-03-30'))
+  expect(goTime.test(next)).toBeTruthy()
+  next = goTime.next(new Date('2022-03-25'), new Date('2022-03-30'))
+  expect(goTime.test(next)).toBeFalsy()
 })


### PR DESCRIPTION
Addresses this Issue:
- #1 

`GoTime.next` searches a date range for the nearest next active time.
`GoTime.toString` returns the definition that was parsed to construct this instance.